### PR TITLE
Version 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ If you find an issue (e.g. something stops working or is behaving oddly), then p
 **Version 1.5.0 - YYYY/MM/DD:**
 - Updated linter to handle statements that span multiple lines.
 - Fixed bug that enabled references in cached scopes to be modifiable by the parser.
+- Fixed comment block implementation in the lexer.
 
 **Version 1.4.0 - 2017/01/20:**
 - Overhaul of the linter and context-sensitive completion systems.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ If you find an issue (e.g. something stops working or is behaving oddly), then p
 - Updated linter to handle statements that span multiple lines.
 - Fixed bug that enabled references in cached scopes to be modifiable by the parser.
 - Fixed comment block implementation in the lexer.
+- Implemented implicit declaration of 'self' variable when declaring method with ':' operator.
 
 **Version 1.4.0 - 2017/01/20:**
 - Overhaul of the linter and context-sensitive completion systems.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ If you find an issue (e.g. something stops working or is behaving oddly), then p
 - Fixed bug that enabled references in cached scopes to be modifiable by the parser.
 - Fixed comment block implementation in the lexer.
 - Implemented implicit declaration of 'self' variable when declaring method with ':' operator.
+- Fixed bug that could cause the linter to crash.
 
 **Version 1.4.0 - 2017/01/20:**
 - Overhaul of the linter and context-sensitive completion systems.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ If you find an issue (e.g. something stops working or is behaving oddly), then p
 - A description of what you did when the issue arose. A detailed set of instructions to reproduce the issue would be ideal.
 
 ## **Changelog**
+**Version 1.5.0 - YYYY/MM/DD:**
+- Updated linter to handle statements that span multiple lines.
+- Fixed bug that enabled references in cached scopes to be modifiable by the parser.
+
 **Version 1.4.0 - 2017/01/20:**
 - Overhaul of the linter and context-sensitive completion systems.
     - Switched from 'dict' instances to instances of classes that represent Lua types.

--- a/Source/Linter.py
+++ b/Source/Linter.py
@@ -1031,31 +1031,12 @@ class Parser(object):
 				line_end = self.processed_tokens[-1].line
 				statements.append(statement)
 				#print("Generated:", self.scope[2:])
-				yield ScopeCache([copy.copy(scope) for scope in self.scope[2:]], line_start, line_end)
+				yield ScopeCache([copy.deepcopy(scope) for scope in self.scope[2:]], line_start, line_end)
 				continue
 			break
 		if not a_completing and len(self.scope) > 4:
 			self.raise_error(ParsingError, "Found %d unterminated scope(s)" % (len(self.scope) - 4))
 		return
-
-		lines = self.tokenize_lines(a_source_code, a_starting_line_index)
-		self.scope = self.get_initial_scope(a_scope)
-		if not lines:
-			return
-		line_number = 0
-		for line in lines:
-			start_time = time.time()
-			line_number = line[0].line
-			self.tokens_to_process = line
-			self.processed_tokens = []
-			statements = self.parse_line()
-			if statements:
-				yield [line_number, statements, copy.copy(self.scope[2:])]
-				# 0 = Line number.
-				# 1 = List of statements.
-				# 2 = Copy of self.scope after parsing this line of Lua code. Used for caching purposes.
-		if not a_completing and len(self.scope) > 4:
-			self.raise_error(ParsingError, "Found %d unterminated scope(s)" % (len(self.scope) - 4))
 
 	#@timed
 	def raise_error(self, a_error_class, a_message, a_line = None, a_column = None,

--- a/Source/Linter.py
+++ b/Source/Linter.py
@@ -1039,7 +1039,7 @@ class Parser(object):
 				yield ScopeCache([copy.deepcopy(scope) for scope in self.scope[2:]], line_start, line_end)
 				continue
 			break
-		if not a_completing and len(self.scope) > 4:
+		if not a_completing and self.scope and len(self.scope) > 4:
 			self.raise_error(ParsingError, "Found %d unterminated scope(s)" % (len(self.scope) - 4))
 		return
 
@@ -1120,6 +1120,8 @@ class Parser(object):
 	#@timed
 	def is_in_scope(self, a_name):
 		#a_name = str(a_name)
+		if not self.scope:
+			return None
 		for scope in reversed(self.scope):
 			existing = scope.get(a_name, None)
 			if existing:
@@ -1476,7 +1478,10 @@ class Parser(object):
 
 			if implicitly_declare_self(a_name, final_parameters):
 				self_table = LuaTable("self")
+				self_table._value = table._value
+				self_table._type = table._type
 				self_table._fields = table._fields
+				self_table._inherited_fields = table._inherited_fields
 				self.push_to_scope(self_table, True)
 		for param in final_parameters:
 			self.push_to_scope(param, True)

--- a/Source/Linter.py
+++ b/Source/Linter.py
@@ -607,7 +607,7 @@ class Parser(object):
 		# Regex patterns used to generate tokens.
 		token_specifications = [
 			(TokenEnum.PREPROCESSOR_COMMAND, r"\-\-\@[^\n\r]*"), # Specific to this parser. Not a part of the Lua language specification!
-			(TokenEnum.BLOCK_COMMENT, r"\-\-\[\[[^\]]*\-\-\]\][^\n\r]*"),
+			(TokenEnum.BLOCK_COMMENT, r"\-\-\[\[.*?\]\]"),
 			(TokenEnum.LINE_COMMENT, r"\-\-[^\n\r]*"),
 			(TokenEnum.NAME, r"[_a-zA-Z][_a-zA-Z0-9]*"),
 			(TokenEnum.DOUBLE_COLON, r"::"),
@@ -649,7 +649,7 @@ class Parser(object):
 			(TokenEnum.NUMBER, r"0[xX][0-9a-fA-F]+[pP][+-]?[0-9]+|0[xX]\.[0-9a-fA-F]+(?:[pP][+-]?[0-9]+)?|0[xX][0-9a-fA-F]+(?:\.[0-9a-fA-F]*(?:[pP][+-]?[0-9]+)?)?|[0-9]+(?:[eE][+-]?[0-9]+)|\.[0-9]+(?:[eE][+-]?[0-9]+)?|[0-9]+(?:\.[0-9]*(?:[eE][+-]?[0-9]+)?)?"),
 			(TokenEnum.UNMATCHED, r"."),
 		]
-		self.token_regex = re.compile("|".join("(?P<t%s>%s)" % pair for pair in token_specifications))
+		self.token_regex = re.compile("|".join("(?P<t%s>%s)" % pair for pair in token_specifications), re.DOTALL)
 		# Regex patterns used to match Lua keywords when a TokenEnum.NAME token has been generated.
 		keyword_specifications = [
 			(TokenEnum.KW_AND, r"and"),

--- a/Source/Linter.py
+++ b/Source/Linter.py
@@ -563,8 +563,13 @@ class LuaTable(LuaVariable):
 		else:
 			return "table"
 
-	def __copy__(self):
-		return LuaTable(self._name, copy.copy(self._fields))
+	def __deepcopy__(self, memo):
+		obj = LuaTable(self._name)
+		obj._value = copy.deepcopy(self._value, memo)
+		obj._type = copy.deepcopy(self._type, memo)
+		obj._fields = copy.deepcopy(self._fields, memo)
+		obj._inherited_fields = self._inherited_fields
+		return obj
 
 	def has_field(self, a_key):
 		if self.get_field(a_key):


### PR DESCRIPTION
- Updated linter to handle statements that span multiple lines.
- Fixed bug that enabled references in cached scopes to be modifiable by the parser.
- Significant performance improvements to deep copying of scopes.
- Fixed comment block implementation in the lexer.
- Implemented implicit declaration of 'self' variable when declaring method with ':' operator.
- Fixed bug that could cause the linter to crash.